### PR TITLE
Change deployment path to use temporary directory

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -47,4 +47,8 @@ jobs:
 
       - name: Deploy dist/ to VM:/pds
         run: |
-          rsync -avz --delete -e "ssh -p ${{ secrets.SSH_PORT }} -i ~/.ssh/id_rsa -o StrictHostKeyChecking=no" ./dist/ ${{ secrets.VM_USER }}@${{ secrets.VM_IP }}:/pds/web/
+          rsync -avz --delete -e "ssh -p ${{ secrets.SSH_PORT }} -i ~/.ssh/id_rsa -o StrictHostKeyChecking=no" ./dist/ ${{ secrets.VM_USER }}@${{ secrets.VM_IP }}:/tmp/web_deploy/
+
+      - name: Move deployed files to final location
+        run: |
+          ssh -p ${{ secrets.SSH_PORT }} -i ~/.ssh/id_rsa -o StrictHostKeyChecking=no ${{ secrets.VM_USER }}@${{ secrets.VM_IP }} "sudo cp -a /tmp/web_deploy/* /pds/web/"


### PR DESCRIPTION
Updated deployment process to first copy files to a temporary directory before moving them to the final location.